### PR TITLE
Redefining  non-negative components. Mij -> 2*Mij. 

### DIFF
--- a/python/AnomalousCouplingEFT.py
+++ b/python/AnomalousCouplingEFT.py
@@ -107,6 +107,10 @@ class AnaliticAnomalousCouplingEFT(PhysicsModel):
                     raise RuntimeError, "Higgs mass range definition requires two extrema"
                 elif float(self.mHRange[0]) >= float(self.mHRange[1]):
                     raise RuntimeError, "Extrema for Higgs mass range defined with inverterd order. Second must be larger the first"
+            if po.startswith("eftOperators="):
+                self.Operators = po.replace("eftOperators=","").split(",")
+                print " Operators = ", self.Operators
+                self.numOperators = len(self.Operators)
 
  
 #
@@ -165,7 +169,7 @@ class AnaliticAnomalousCouplingEFT(PhysicsModel):
 
           # interference between pairs of Wilson coefficients
           for operator_sub in range(operator+1, self.numOperators):
-            self.modelBuilder.factory_("expr::linear_func_mixed_" + str(self.Operators[operator]) + "_" + str(self.Operators[operator_sub]) +"(\"@0*2*@1*@2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) + ")")
+            self.modelBuilder.factory_("expr::linear_func_mixed_" + str(self.Operators[operator]) + "_" + str(self.Operators[operator_sub]) +"(\"@0*@1*@2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) + ")")
             #print "expr::linear_func_mixed_" + str(self.Operators[operator]) + "_" + str(self.Operators[operator_sub]) +"(\"@0*@1*@2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) + ")"
             
         print " parameters of interest = ", self.poiNames

--- a/python/AnomalousCouplingEFTNegative.py
+++ b/python/AnomalousCouplingEFTNegative.py
@@ -304,22 +304,23 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
             if self.numOperators != 1:
               #for operator_sub in range(operator+1, self.numOperators):
 
-              print "expr::func_quadratic_"+ str(self.Operators[operator]) +                                                                                              \
-                                        "(\"@0*(@1*@1-@1-2*@1*(" + "@" + "+@".join([str(j+1) for j in range(len(self.Operators)) if j != 0 ]) +   \
+              print "expr::func_quadratic_"+ str(self.Operators[operator]) +    \
+                                        "(\"@0*(@1*@1-@1-@1*(" + "@" + "+@".join([str(j+1) for j in range(len(self.Operators)) if j != 0 ]) +   \
                                         "))\",r," + "k_" +  str(self.Operators[operator]) + ", k_" + ", k_".join([str(self.Operators[i]) for i in range(len(self.Operators)) if i != operator ]) + ")"
 
-              self.modelBuilder.factory_("expr::func_quadratic_"+ str(self.Operators[operator]) +                                                                                              \
-                                        "(\"@0*(@1*@1-@1-2*@1*(" + "@" + "+@".join([str(j+1) for j in range(len(self.Operators)) if j != 0 ]) +   \
+              self.modelBuilder.factory_("expr::func_quadratic_"+ str(self.Operators[operator]) +      \
+                                        "(\"@0*(@1*@1-@1-@1*(" + "@" + "+@".join([str(j+1) for j in range(len(self.Operators)) if j != 0 ]) +   \
                                         "))\",r," + "k_" +  str(self.Operators[operator]) + ", k_" + ", k_".join([str(self.Operators[i]) for i in range(len(self.Operators)) if i != operator ]) + ")"
                                         )
+                                                                                                                                                                                
 
             else:
 
-              print "expr::func_quadratic_"+ str(self.Operators[0]) +                                                                                              \
+              print "expr::func_quadratic_"+ str(self.Operators[0]) + \
                                         "(\"@0*(@1*@1-@1" +   \
                                         ")\",r,k_" + str(self.Operators[0]) + ")"
 
-              self.modelBuilder.factory_("expr::func_quadratic_"+ str(self.Operators[operator]) +                                                                                              \
+              self.modelBuilder.factory_("expr::func_quadratic_"+ str(self.Operators[operator]) +  \
                                         "(\"@0*(@1*@1-@1" +   \
                                         ")\",r,k_" + str(self.Operators[0]) + ")"
                                         )
@@ -357,12 +358,12 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
                 # Since I have only Mij (and I do not define the sample Mji)
                 #
                 print "expr::func_quadratic_mixed_" + str(self.Operators[operator_sub]) + "_" + str(self.Operators[operator]) +          \
-                "(\"@0*@1*@2*2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) +                      \
+                "(\"@0*@1*@2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) +                      \
                 ")"
 
                 self.modelBuilder.factory_(
                         "expr::func_quadratic_mixed_" + str(self.Operators[operator_sub]) + "_" + str(self.Operators[operator]) +
-                        "(\"@0*@1*@2*2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) +
+                        "(\"@0*@1*@2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) +
                         ")")
 
 

--- a/python/AnomalousCouplingEFTNegative.py
+++ b/python/AnomalousCouplingEFTNegative.py
@@ -179,7 +179,7 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
           if self.numOperators != 1:
               print "expr::func_sm(\"@0*(1-(" +                                                                                                                                                                  \
                              "@" + "+@".join([str(i+1) for i in range(len(self.Operators))])  +                                                                                                               \
-                             "-@" + "-@".join([str(i+1)+"*@"+str(j+1) for i in range(len(self.Operators)) for j in range(len(self.Operators)) if j!=i ]) +                                                     \
+                             "-@" + "-@".join([str(i+1)+"*@"+str(j+1) for i in range(len(self.Operators)) for j in range(len(self.Operators)) if i<j ]) +                                                     \
                              "))\",r," + "k_" + ", k_".join([str(self.Operators[i]) for i in range(len(self.Operators))]) + ")"
           else:
             print "expr::func_sm(\"@0*(1-(" +                                                                     \
@@ -189,7 +189,7 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
             self.modelBuilder.factory_(
                  "expr::func_sm(\"@0*(1-(" +
                                           "@" + "+@".join([str(i+1) for i in range(len(self.Operators))])  +
-                                          "-@" + "-@".join([str(i+1)+"*@"+str(j+1) for i in range(len(self.Operators)) for j in range(len(self.Operators)) if j!=i ]) +
+                                          "-@" + "-@".join([str(i+1)+"*@"+str(j+1) for i in range(len(self.Operators)) for j in range(len(self.Operators)) if i<j ]) +
                                           "))\",r," + "k_" + ", k_".join([str(self.Operators[i]) for i in range(len(self.Operators))]) + ")"
                  )
           else :
@@ -234,7 +234,7 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
               #print " Test = "
               print "expr::func_sm_linear_quadratic_" + str(self.Operators[operator]) +                                           \
                                  "(\"@0*(" +                                                                                      \
-                                 "@1 * (1-2*(" + "@" + "+@".join( [str(j+2) for j in range(len(self.Operators) -1) ] ) + ") )" +      \
+                                 "@1 * (1-(" + "@" + "+@".join( [str(j+2) for j in range(len(self.Operators) -1) ] ) + ") )" +      \
                                  ")\",r,k_" + str(self.Operators[operator]) +                                                     \
                                  ", k_" + ", k_".join( [str(self.Operators[j]) for j in range(len(self.Operators)) if operator!=j ] ) +            \
                                  ")"
@@ -246,7 +246,7 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
               self.modelBuilder.factory_(
                       "expr::func_sm_linear_quadratic_" + str(self.Operators[operator]) +
                                  "(\"@0*(" +
-                                 "@1 * (1-2*(" + "@" + "+@".join( [str(j+2) for j in range(len(self.Operators) -1) ] ) + ") )" +
+                                 "@1 * (1-(" + "@" + "+@".join( [str(j+2) for j in range(len(self.Operators) -1) ] ) + ") )" +
                                  ")\",r,k_" + str(self.Operators[operator]) +
                                  ", k_" + ", k_".join( [str(self.Operators[j]) for j in range(len(self.Operators)) if operator!=j ] ) +
                                  ")"
@@ -339,12 +339,12 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
                 # Since I have only Mij (and I do not define the sample Mji)
                 #
                 print "expr::func_sm_linear_quadratic_mixed_" + str(self.Operators[operator_sub]) + "_" + str(self.Operators[operator]) +          \
-                "(\"@0*@1*@2*2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) +                      \
+                "(\"@0*@1*@2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) +                      \
                 ")"
 
                 self.modelBuilder.factory_(
                         "expr::func_sm_linear_quadratic_mixed_" + str(self.Operators[operator_sub]) + "_" + str(self.Operators[operator]) +
-                        "(\"@0*@1*@2*2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) +
+                        "(\"@0*@1*@2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) +
                         ")")
 
         else:


### PR DESCRIPTION
- Changed model EFT ( the one with negative components ) removed the 2* as we are inserting M_ij + M_ji = 2*M_ij.
   without this i could not test the old vs new models

- Changed coefficients of the EFTNegative following the algebra derived for SM + L_i + L_j + Q_i + Q_j + 2*M_ij, in particular:
       - SM coefficient: changed the last sum, now runs on i < j (before i != j)
       - SM + L_i + Q_i coefficient: removed the 2* factor
       - SM + L_i + L_j + Q_i + Q_j + 2*M_ij coefficient: removed the 2* factor