### PR TITLE
Check if not all operators are available

### DIFF
--- a/python/AnomalousCouplingEFTNegative.py
+++ b/python/AnomalousCouplingEFTNegative.py
@@ -452,7 +452,7 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
         # since it is NOT used by the model, and otherwise it would be treated as
         # a background, thus being a mistake!
         #
-        for complete_list_of_operators in CompleteOperators:
+        for complete_list_of_operators in self.CompleteOperators:
           if complete_list_of_operators in process:
             return 0
             #

--- a/python/AnomalousCouplingEFTNegative.py
+++ b/python/AnomalousCouplingEFTNegative.py
@@ -125,6 +125,9 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
              'cuu1'
              ]
 
+
+        self.CompleteOperators = self.Operators + self.OperatorsDim8
+
         self.numOperators = len(self.Operators)
 
         print " Operators = ", self.Operators
@@ -437,6 +440,32 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
               if process == "quad_mixed_"+ str(self.Operators[operator]) + "_"+ str(self.Operators[operator_sub]) :    return "func_quadratic_mixed_" + str(self.Operators[operator_sub]) + "_" + str(self.Operators[operator])
               if process == "quad_mixed_"+ str(self.Operators[operator_sub]) + "_"+ str(self.Operators[operator]) :    return "func_quadratic_mixed_" + str(self.Operators[operator_sub]) + "_" + str(self.Operators[operator])
 
+        
+        
+        #
+        # sometimes we have complete datacards, with many operators, but we want to test 
+        # a model just with few operators, 
+        # for example if we need to combine a datacard with dependency only on 2 operators
+        # with another that depends on 3 (thus having many more components).
+        # If this is the case, compare the complete list of operators
+        # and if any of them appear in the "process" then this process is scaled to 0
+        # since it is NOT used by the model, and otherwise it would be treated as
+        # a background, thus being a mistake!
+        #
+        for complete_list_of_operators in CompleteOperators:
+          if complete_list_of_operators in process:
+            return 0
+            #
+            # No need to remove the list in "Operators"
+            # since if it was to be used there, the "return" would 
+            # have been already called.
+            # This option will be triggered only if no return was already called
+            # and if not "return 0" we would have "return 1" underneath,
+            # thus considering this as background
+            # NB: the names in "CompleteOperators" are wild cards
+            # and should not be used by other samples (real background!)
+            # but, com'on, a bit of rules!
+            #
 
 
         return 1

--- a/test/README.md
+++ b/test/README.md
@@ -162,5 +162,60 @@ Otherwise I need a flag of the operators that I want IN THE MODEL BUILDING
           --PO  eftAlternative
     
     
+
+    text2workspace.py        datacard_cHDD_mjj_1D.txt -P HiggsAnalysis.AnalyticAnomalousCoupling.AnomalousCouplingEFTNegative:analiticAnomalousCouplingEFTNegative   -o   model_test_1_wrong.root    --X-allow-no-signal  \
+          --PO eftOperators=cHDD,cHWB  \    
+    
+    text2workspace.py        datacard_cHDD_mjj_1D.txt -P HiggsAnalysis.AnalyticAnomalousCoupling.AnomalousCouplingEFTNegative:analiticAnomalousCouplingEFTNegative   -o   model_test_1.root    --X-allow-no-signal  \
+          --PO eftOperators=cHDD  \
+      
+    text2workspace.py        datacard_cHDD_cHWB_mjj_2D.txt -P HiggsAnalysis.AnalyticAnomalousCoupling.AnomalousCouplingEFTNegative:analiticAnomalousCouplingEFTNegative   -o   model_test_2.root    --X-allow-no-signal  \
+          --PO eftOperators=cHDD,cHWB  \
+
+    text2workspace.py        datacard_cHDD_cHWB_mjj_2D.txt -P HiggsAnalysis.AnalyticAnomalousCoupling.AnomalousCouplingEFTNegative:analiticAnomalousCouplingEFTNegative   -o   model_test_2_correct.root    --X-allow-no-signal  \
+          --PO eftOperators=cHDD  \
+          
+
+          
+          
+    combine -M MultiDimFit model_test_1_wrong.root  --algo=grid --points 2000  -m 125   -t -1     \
+        --redefineSignalPOIs k_cHDD \
+        --freezeParameters r  \
+        --setParameters r=1    --setParameterRanges k_cHDD=-10,10     \
+        --verbose -1
+    mv higgsCombineTest.MultiDimFit.mH125.root scan_model_test_1_wrong.root
+
+    
+    combine -M MultiDimFit model_test_1.root  --algo=grid --points 2000  -m 125   -t -1     \
+        --redefineSignalPOIs k_cHDD \
+        --freezeParameters r  \
+        --setParameters r=1    --setParameterRanges k_cHDD=-10,10     \
+        --verbose -1
+    mv higgsCombineTest.MultiDimFit.mH125.root scan_model_test_1.root
+    
+    
+    combine -M MultiDimFit model_test_2.root  --algo=grid --points 2000  -m 125   -t -1     \
+        --redefineSignalPOIs k_cHDD \
+        --freezeParameters r,k_cHWB  \
+        --setParameters r=1,k_cHWB=0    --setParameterRanges k_cHDD=-10,10     \
+        --verbose -1
+    mv higgsCombineTest.MultiDimFit.mH125.root scan_model_test_2.root
+    
+    
+    combine -M MultiDimFit model_test_2_correct.root  --algo=grid --points 2000  -m 125   -t -1     \
+        --redefineSignalPOIs k_cHDD \
+        --freezeParameters r  \
+        --setParameters r=1    --setParameterRanges k_cHDD=-10,10     \
+        --verbose -1
+    mv higgsCombineTest.MultiDimFit.mH125.root scan_model_test_2_correct.root
+     
+     
+    r99t scan_model_test_1.root  scan_model_test_1_wrong.root   draw.cxx\(\"k_cHDD\"\)    --> they are different, since missing pieces and formula is wrong
+    r99t scan_model_test_1.root  scan_model_test_2.root   draw.cxx\(\"k_cHDD\"\)          --> they are the same
+    r99t scan_model_test_1.root  scan_model_test_2_correct.root   draw.cxx\(\"k_cHDD\"\)  --> they are the same
+    r99t scan_model_test_2.root  scan_model_test_2_correct.root   draw.cxx\(\"k_cHDD\"\)  --> they are the same, thanks to the new fix (return 0) in the model
+
+    
+    
     
     


### PR DESCRIPTION
Case when you have more inputs in the datacard, but you don't need them (for example a datacard created for 3 operators, but later you want to fit only 2 of them).
It will "return 0" for samples involving un-used operators.