### PR TITLE
Run-time command arguments for combine to handle negative bins

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Negative bin yield
 
 It may happen that the expected yield (SM+EFT) in a bin evaluates negative. Combine will complain and return the maximum FCN value up to that point in the minimization to force MIGRAD to back out of the region. If one want to disable such behaviour and ignore the negative bin (setting its content to zero) add to the combine command the following run-time arguments
 
-   --X-rtd SIMNLL_NO_LEE --X-rtd NO_ADDNLL_FASTEXIT
+   `--X-rtd SIMNLL_NO_LEE --X-rtd NO_ADDNLL_FASTEXIT`
 
 
 The partial sums will be set to one (so log is zero) and no error will be propagated to RooFit: 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,21 @@ but you can also just define the new operators by
     --PO eftOperators=cS0,cS1,cT0
     
     
-    
 
-    
+Negative bin yield    
+===
+
+It may happen that the expected yield (SM+EFT) in a bin evaluates negative. Combine will complain and return the maximum FCN value up to that point in the minimization to force MIGRAD to back out of the region. If one want to disable such behaviour and ignore the negative bin (setting its content to zero) add to the combine command the following run-time arguments
+
+   --X-rtd SIMNLL_NO_LEE --X-rtd NO_ADDNLL_FASTEXIT
+
+
+The partial sums will be set to one (so log is zero) and no error will be propagated to RooFit: 
+
+https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/7bffa8b8758a5dc6824b8b93c098ce9afb1c32a4/src/CachingNLL.cc#L691
+
+https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/7bffa8b8758a5dc6824b8b93c098ce9afb1c32a4/src/CachingNLL.cc#L692
+
     
 Older examples
 ====


### PR DESCRIPTION
The `CachingSimNLL::hasError_ = true` in 
https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/7bffa8b8758a5dc6824b8b93c098ce9afb1c32a4/src/CachingNLL.cc#L691

Is disabled by `--X-rtd SIMNLL_NO_LEE`, and won't trigger FCN max return in RooFit during the minimisation.

The `FASTEXIT` will instead be handled by `--X-rtd NO_ADDNLL_FASTEXIT` which is defined as variable `fastExit_` in `CachinNLL.cc`: https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/7bffa8b8758a5dc6824b8b93c098ce9afb1c32a4/src/CachingNLL.cc#L692

Instead of returning `9e9` as current nll value for that bin, it will return 1 so that log evaluates to zero:
https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/7bffa8b8758a5dc6824b8b93c098ce9afb1c32a4/src/CachingNLL.cc#L693

If the overall expected yield is negative (integral of SM+EFT) one can also disable the error trigger:

https://github.com/cms-analysis/HiggsAnalysis-CombinedLimit/blob/7bffa8b8758a5dc6824b8b93c098ce9afb1c32a4/src/CachingNLL.cc#L708

But this will probably trigger other errors and one should instead checks his datacard.