### PR TITLE
Ported to python3 using 2to3 script

### DIFF
--- a/python/AnaliticAnomalousCouplingEFTNegativeExtended.py
+++ b/python/AnaliticAnomalousCouplingEFTNegativeExtended.py
@@ -137,7 +137,7 @@ class AnaliticAnomalousCouplingEFTNegativeExtended(PhysicsModel):
         self.CompleteOperators = self.Operators + self.OperatorsDim8
 
         self.numOperators = len(self.Operators)
-        print " Operators = ", self.Operators
+        print(" Operators = ", self.Operators)
 
 
     def setPhysicsOptions(self,physOptions):
@@ -145,13 +145,13 @@ class AnaliticAnomalousCouplingEFTNegativeExtended(PhysicsModel):
             if po.startswith("higgsMassRange="):
                 self.mHRange = po.replace("higgsMassRange=","").split(",")
                 if len(self.mHRange) != 2:
-                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                    raise RuntimeError("Higgs mass range definition requires two extrema")
                 elif float(self.mHRange[0]) >= float(self.mHRange[1]):
-                    raise RuntimeError, "Extrema for Higgs mass range defined with inverterd order. Second must be larger the first"
+                    raise RuntimeError("Extrema for Higgs mass range defined with inverterd order. Second must be larger the first")
 
             if po.startswith("eftOperators="):
                 self.Operators = po.replace("eftOperators=","").split(",")
-                print " Operators = ", self.Operators
+                print(" Operators = ", self.Operators)
                 self.numOperators = len(self.Operators)
 
             if po.startswith("eftAlternative"):
@@ -438,7 +438,7 @@ class AnaliticAnomalousCouplingEFTNegativeExtended(PhysicsModel):
         # Building PDF for EFT2Obs datacards only if specified by command line options
         if self.UseEFT2Obs:
 
-          for an_ in self.json_map.keys():
+          for an_ in list(self.json_map.keys()):
 
             # build the function 
             op_dict = {k: {"par": "k_" + k, "at": "@"+str(idx+1)} for idx, k in enumerate(self.Operators)}
@@ -468,13 +468,13 @@ class AnaliticAnomalousCouplingEFTNegativeExtended(PhysicsModel):
                   if all(i in self.Operators for i in b[2:]):
                     func += " + {}*{}*{} ".format(b[0], op_dict[b[2]]["at"], op_dict[b[3]]["at"])
               
-              func += ")\",r,k_" + ",k_".join( it_[0] for it_ in sorted(op_dict.items(), key= lambda x: x[1] ) )  + ")"
+              func += ")\",r,k_" + ",k_".join( it_[0] for it_ in sorted(list(op_dict.items()), key= lambda x: x[1] ) )  + ")"
               print(func)
               self.modelBuilder.factory_(func) 
               
 
-        print " parameters of interest = ", self.poiNames
-        print " self.numOperators = ", self.numOperators
+        print(" parameters of interest = ", self.poiNames)
+        print(" self.numOperators = ", self.numOperators)
         
         self.modelBuilder.doSet("POI",self.poiNames)
 
@@ -514,9 +514,9 @@ class AnaliticAnomalousCouplingEFTNegativeExtended(PhysicsModel):
                 return "func_quadratic_mixed_" + str(self.Operators[operator_sub]) + "_" + str(self.Operators[operator])
 
         if self.UseEFT2Obs:
-          for an_ in self.json_map.keys():
+          for an_ in list(self.json_map.keys()):
             if process in self.json_map[an_]["bin_labels"]:
-              print("---> Will scale " + process + " with " + "func_EFT2Obs_" + process)
+              print(("---> Will scale " + process + " with " + "func_EFT2Obs_" + process))
               return "func_EFT2Obs_" + process
 
         

--- a/python/AnomalousCoupling.py
+++ b/python/AnomalousCoupling.py
@@ -16,9 +16,9 @@ class AnaliticAnomalousCoupling(PhysicsModel):
             if po.startswith("higgsMassRange="):
                 self.mHRange = po.replace("higgsMassRange=","").split(",")
                 if len(self.mHRange) != 2:
-                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                    raise RuntimeError("Higgs mass range definition requires two extrema")
                 elif float(self.mHRange[0]) >= float(self.mHRange[1]):
-                    raise RuntimeError, "Extrema for Higgs mass range defined with inverterd order. Second must be larger the first"
+                    raise RuntimeError("Extrema for Higgs mass range defined with inverterd order. Second must be larger the first")
 
             if po.startswith("numOperators="):
                self.numOperators = int ( po.replace("numOperators=","") )
@@ -75,8 +75,8 @@ class AnaliticAnomalousCoupling(PhysicsModel):
           self.modelBuilder.factory_("expr::quadratic_func_"+ str(operator) + "(\"@0*@1*@1\",r,k_my_" + str(operator) + ")")
           
           
-        print " parameters of interesst = "
-        print self.poiNames
+        print(" parameters of interesst = ")
+        print(self.poiNames)
         self.modelBuilder.doSet("POI",self.poiNames)
 
 

--- a/python/AnomalousCouplingEFT.py
+++ b/python/AnomalousCouplingEFT.py
@@ -112,12 +112,12 @@ class AnaliticAnomalousCouplingEFT(PhysicsModel):
             if po.startswith("higgsMassRange="):
                 self.mHRange = po.replace("higgsMassRange=","").split(",")
                 if len(self.mHRange) != 2:
-                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                    raise RuntimeError("Higgs mass range definition requires two extrema")
                 elif float(self.mHRange[0]) >= float(self.mHRange[1]):
-                    raise RuntimeError, "Extrema for Higgs mass range defined with inverterd order. Second must be larger the first"
+                    raise RuntimeError("Extrema for Higgs mass range defined with inverterd order. Second must be larger the first")
             if po.startswith("eftOperators="):
                 self.Operators = po.replace("eftOperators=","").split(",")
-                print " Operators = ", self.Operators
+                print(" Operators = ", self.Operators)
                 self.numOperators = len(self.Operators)
 
  
@@ -180,7 +180,7 @@ class AnaliticAnomalousCouplingEFT(PhysicsModel):
             self.modelBuilder.factory_("expr::linear_func_mixed_" + str(self.Operators[operator]) + "_" + str(self.Operators[operator_sub]) +"(\"@0*@1*@2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) + ")")
             #print "expr::linear_func_mixed_" + str(self.Operators[operator]) + "_" + str(self.Operators[operator_sub]) +"(\"@0*@1*@2\",r,k_" + str(self.Operators[operator]) + ",k_" + str(self.Operators[operator_sub]) + ")"
             
-        print " parameters of interest = ", self.poiNames
+        print(" parameters of interest = ", self.poiNames)
         self.modelBuilder.doSet("POI",self.poiNames)
 
 

--- a/python/AnomalousCouplingEFTNegative.py
+++ b/python/AnomalousCouplingEFTNegative.py
@@ -135,7 +135,7 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
         self.CompleteOperators = self.Operators + self.OperatorsDim8
 
         self.numOperators = len(self.Operators)
-        print " Operators = ", self.Operators
+        print(" Operators = ", self.Operators)
 
 
     def setPhysicsOptions(self,physOptions):
@@ -143,13 +143,13 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
             if po.startswith("higgsMassRange="):
                 self.mHRange = po.replace("higgsMassRange=","").split(",")
                 if len(self.mHRange) != 2:
-                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                    raise RuntimeError("Higgs mass range definition requires two extrema")
                 elif float(self.mHRange[0]) >= float(self.mHRange[1]):
-                    raise RuntimeError, "Extrema for Higgs mass range defined with inverterd order. Second must be larger the first"
+                    raise RuntimeError("Extrema for Higgs mass range defined with inverterd order. Second must be larger the first")
 
             if po.startswith("eftOperators="):
                 self.Operators = po.replace("eftOperators=","").split(",")
-                print " Operators = ", self.Operators
+                print(" Operators = ", self.Operators)
                 self.numOperators = len(self.Operators)
 
             if po.startswith("eftAlternative"):
@@ -167,18 +167,18 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
             #
             if po.startswith("defineCompleteOperators="):
                 self.CompleteOperators = po.replace("defineCompleteOperators=","").split(",")
-                print " CompleteOperators = ", self.CompleteOperators
+                print(" CompleteOperators = ", self.CompleteOperators)
 
             if po.startswith("addToCompleteOperators="):
                 toAddOperators = po.replace("addToCompleteOperators=","").split(",")
                 self.CompleteOperators.extend ( toAddOperators )
-                print " CompleteOperators = ", self.CompleteOperators
+                print(" CompleteOperators = ", self.CompleteOperators)
 
             if po.startswith("removeFromCompleteOperators="):
                 toRemoveOperators = po.replace("removeFromCompleteOperators=","").split(",")
                 newlist = [i for i in self.CompleteOperators if i not in toRemoveOperators]
                 self.CompleteOperators = newlist
-                print " CompleteOperators = ", self.CompleteOperators
+                print(" CompleteOperators = ", self.CompleteOperators)
 
 
 #
@@ -435,8 +435,8 @@ class AnaliticAnomalousCouplingEFTNegative(PhysicsModel):
 
 
 
-        print " parameters of interest = ", self.poiNames
-        print " self.numOperators = ", self.numOperators
+        print(" parameters of interest = ", self.poiNames)
+        print(" self.numOperators = ", self.numOperators)
         
         self.modelBuilder.doSet("POI",self.poiNames)
 

--- a/python/AnomalousCouplingLinearEFTNegative.py
+++ b/python/AnomalousCouplingLinearEFTNegative.py
@@ -142,7 +142,7 @@ class AnaliticAnomalousCouplingLinearEFTNegative(PhysicsModel):
 
         self.numOperators = len(self.Operators)
 
-        print " Operators = ", self.Operators
+        print(" Operators = ", self.Operators)
 
         
         
@@ -152,13 +152,13 @@ class AnaliticAnomalousCouplingLinearEFTNegative(PhysicsModel):
             if po.startswith("higgsMassRange="):
                 self.mHRange = po.replace("higgsMassRange=","").split(",")
                 if len(self.mHRange) != 2:
-                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                    raise RuntimeError("Higgs mass range definition requires two extrema")
                 elif float(self.mHRange[0]) >= float(self.mHRange[1]):
-                    raise RuntimeError, "Extrema for Higgs mass range defined with inverterd order. Second must be larger the first"
+                    raise RuntimeError("Extrema for Higgs mass range defined with inverterd order. Second must be larger the first")
 
             if po.startswith("eftOperators="):
                 self.Operators = po.replace("eftOperators=","").split(",")
-                print " Operators = ", self.Operators
+                print(" Operators = ", self.Operators)
                 self.numOperators = len(self.Operators)
 
             if po.startswith("addDim8"):
@@ -167,7 +167,7 @@ class AnaliticAnomalousCouplingLinearEFTNegative(PhysicsModel):
 
             if po.startswith("reuseCompleteDatacards"):
                 self.reuseCompleteDatacards = True
-                print " reuseCompleteDatacards = ", self.reuseCompleteDatacards
+                print(" reuseCompleteDatacards = ", self.reuseCompleteDatacards)
                 
 
 #
@@ -276,8 +276,8 @@ class AnaliticAnomalousCouplingLinearEFTNegative(PhysicsModel):
                        "(\"-@0*@1\",r," + "k_" + str(self.Operators[operator]) + ")"
                  )
           
-        print " parameters of interest = ", self.poiNames
-        print " self.numOperators = ", self.numOperators
+        print(" parameters of interest = ", self.poiNames)
+        print(" self.numOperators = ", self.numOperators)
         
         self.modelBuilder.doSet("POI",self.poiNames)
 

--- a/python/AnomalousCouplingOneOp.py
+++ b/python/AnomalousCouplingOneOp.py
@@ -19,9 +19,9 @@ class AnaliticAnomalousCouplingOneOp(PhysicsModel):
             if po.startswith("higgsMassRange="):
                 self.mHRange = po.replace("higgsMassRange=","").split(",")
                 if len(self.mHRange) != 2:
-                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                    raise RuntimeError("Higgs mass range definition requires two extrema")
                 elif float(self.mHRange[0]) >= float(self.mHRange[1]):
-                    raise RuntimeError, "Extrema for Higgs mass range defined with inverterd order. Second must be larger the first"
+                    raise RuntimeError("Extrema for Higgs mass range defined with inverterd order. Second must be larger the first")
 
 #
 # standard, not touched (end)
@@ -53,7 +53,7 @@ class AnaliticAnomalousCouplingOneOp(PhysicsModel):
         self.modelBuilder.factory_("expr::linear_func(\"@0*@1\",r,k_my)")
         self.modelBuilder.factory_("expr::quadratic_func(\"@0*@1*@1\",r,k_my)")
 
-        print self.poiNames
+        print(self.poiNames)
         self.modelBuilder.doSet("POI",self.poiNames)
 
 

--- a/python/AnomalousCouplingTwoOp.py
+++ b/python/AnomalousCouplingTwoOp.py
@@ -21,9 +21,9 @@ class AnaliticAnomalousCouplingTwoOp(PhysicsModel):
             if po.startswith("higgsMassRange="):
                 self.mHRange = po.replace("higgsMassRange=","").split(",")
                 if len(self.mHRange) != 2:
-                    raise RuntimeError, "Higgs mass range definition requires two extrema"
+                    raise RuntimeError("Higgs mass range definition requires two extrema")
                 elif float(self.mHRange[0]) >= float(self.mHRange[1]):
-                    raise RuntimeError, "Extrema for Higgs mass range defined with inverterd order. Second must be larger the first"
+                    raise RuntimeError("Extrema for Higgs mass range defined with inverterd order. Second must be larger the first")
 
 #
 # standard, not touched (end)
@@ -63,7 +63,7 @@ class AnaliticAnomalousCouplingTwoOp(PhysicsModel):
         self.modelBuilder.factory_("expr::quadratic_func_1(\"@0*@1*@1\",r,k_my_1)")
         self.modelBuilder.factory_("expr::quadratic_func_2(\"@0*@1*@1\",r,k_my_2)")
 
-        print self.poiNames
+        print(self.poiNames)
         self.modelBuilder.doSet("POI",self.poiNames)
 
 

--- a/scripts/HistoRy.py
+++ b/scripts/HistoRy.py
@@ -83,7 +83,7 @@ class HistoBuilder:
 
 
         c = dict.fromkeys(self.pois)
-        self.pois = c.keys()
+        self.pois = list(c.keys())
 
         self.ppois = list(combinations(self.pois, 2))
 
@@ -155,7 +155,7 @@ class HistoBuilder:
         print("#####################")
         print(poiInterest)
         print("#####################")
-        print(self.minimPoisValue)
+        print((self.minimPoisValue))
         print("#####################")
 
         self.historySingleHistos[poiInterest] = {}
@@ -176,7 +176,7 @@ class HistoBuilder:
         fact += poiPair_sum
         fact *= self.minimPoisValue["r"]
 
-        print("--> SM fact " + str(fact))
+        print(("--> SM fact " + str(fact)))
 
         bench.Scale(fact)
         self.historySingleHistos[poiInterest]["SM"] = deepcopy(bench)
@@ -193,7 +193,7 @@ class HistoBuilder:
 
             fact*=self.minimPoisValue["r"]
 
-            print("--> Sm li qu {} fact ".format(poi) + str(fact))
+            print(("--> Sm li qu {} fact ".format(poi) + str(fact)))
 
             h.Scale(fact)
             self.historySingleHistos[poiInterest]["sm_lin_quad_"+ poi.strip("k_")] = h
@@ -202,7 +202,7 @@ class HistoBuilder:
         #qu
         for poi in self.pois:
             h = deepcopy(self.shapes["histo_quad_" + poi.strip("k_")])
-            print("--> qu {} fact ".format(poi) + str(self.minimPoisValue["r"]*(self.minimPoisValue[poi]*self.minimPoisValue[poi] - self.minimPoisValue[poi])))
+            print(("--> qu {} fact ".format(poi) + str(self.minimPoisValue["r"]*(self.minimPoisValue[poi]*self.minimPoisValue[poi] - self.minimPoisValue[poi]))))
             h.Scale( self.minimPoisValue["r"]*(self.minimPoisValue[poi]*self.minimPoisValue[poi] - self.minimPoisValue[poi]) )
             self.historySingleHistos[poiInterest]["quad_"+ poi.strip("k_")] = h
             
@@ -213,17 +213,17 @@ class HistoBuilder:
 
             name = "histo_sm_lin_quad_mixed_" + ppair[0].strip("k_") + "_" + ppair[1].strip("k_")
 
-            if name not in  self.shapes.keys():
+            if name not in  list(self.shapes.keys()):
                 name = "histo_sm_lin_quad_mixed_" + ppair[1].strip("k_") + "_" + ppair[0].strip("k_")
 
-                if name not in  self.shapes.keys():
-                    print ("No shape for {} {}".format(ppair[0], ppair[1]))
+                if name not in  list(self.shapes.keys()):
+                    print(("No shape for {} {}".format(ppair[0], ppair[1])))
                     continue
 
             h = deepcopy(self.shapes[name])
             fact = self.minimPoisValue["r"] * self.minimPoisValue[ppair[0]] * self.minimPoisValue[ppair[1]]
 
-            print("--> mixed {} {} fact ".format(ppair[0], ppair[1]) + str(fact))
+            print(("--> mixed {} {} fact ".format(ppair[0], ppair[1]) + str(fact)))
 
             h.Scale(fact)
             self.historySingleHistos[poiInterest][name.split("histo_")[1]] = h
@@ -233,7 +233,7 @@ class HistoBuilder:
 
         #print(bench.Integral(), self.shapes["histo_sm"].Integral())
         if bench.GetMinimum() < 0:
-            print ("foundBin < 0" + str(bench.GetMinimum()) )
+            print(("foundBin < 0" + str(bench.GetMinimum()) ))
             
         return bench
 
@@ -247,7 +247,7 @@ class HistoBuilder:
         for event in t:
             for poi in self.pois:
                 self.minimPoisValue[poi] = getattr(event, poi)
-            for key in self.rateParam.keys():
+            for key in list(self.rateParam.keys()):
                 self.rateParam[key].append(getattr(event, key))
 
             self.minimPoisValue["r"] = 1 if not self.has_r_SignalStrength else getattr(event, "r")

--- a/scripts/convertAACtoIM.py
+++ b/scripts/convertAACtoIM.py
@@ -165,12 +165,12 @@ if __name__ == "__main__":
    ops = args.operators
 
    if not args.nodumping:
-      print("Removing all EFT templates from original datacard and dumping in {}".format(sys.argv[3]))
+      print(("Removing all EFT templates from original datacard and dumping in {}".format(sys.argv[3])))
       dumpEFT(args.input, args.output)
 
    if not args.noscaling: 
 
-      print("Running the scaling for {}".format(" ".join(ops)))
+      print(("Running the scaling for {}".format(" ".join(ops))))
       shapefiles = {}
       f = open(args.input, "r")
       lines = f.readlines()
@@ -187,7 +187,7 @@ if __name__ == "__main__":
 
 
       scaling = []
-      for channel in shapefiles.keys():
+      for channel in list(shapefiles.keys()):
          sd = {}
          sd["process"] = "sm"
          sd["channel"] = channel
@@ -212,7 +212,7 @@ if __name__ == "__main__":
             elif shapefiles[channel]["nominal"] + "sm_lin_quad_mixed_" + c[1] + "_" + c[0] in [i.GetName() for i in f.GetListOfKeys()]:
                matrix["sm_lin_quad_mixed_" + c[1] + "_" + c[0]] = f.Get(shapefiles[channel]["nominal"] + "sm_lin_quad_mixed_" + c[1] + "_" + c[0])
             else:
-               print("Error {} {}".format(shapefiles[channel]["path"], "sm_lin_quad_mixed_" + c[1] + "_" + c[0]))
+               print(("Error {} {}".format(shapefiles[channel]["path"], "sm_lin_quad_mixed_" + c[1] + "_" + c[0])))
 
          # add lin and mixed after we filled the matrix
          for op in ops:  
@@ -225,7 +225,7 @@ if __name__ == "__main__":
 
          for c in combo:
 
-            if "sm_lin_quad_mixed_" + c[1] + "_" + c[0] in matrix.keys():
+            if "sm_lin_quad_mixed_" + c[1] + "_" + c[0] in list(matrix.keys()):
                name = "mix_" + c[0] + "_" + c[1]
                matrix[name] = matrix["sm_lin_quad_mixed_" + c[1] + "_" + c[0]].Clone(name)
                matrix[name].Add(matrix["sm"])
@@ -233,7 +233,7 @@ if __name__ == "__main__":
                matrix[name].Add(matrix["sm_lin_quad_" + c[1]], -1)
                # divide by 2 linears
                matrix[name].Scale(1./2)
-            elif "sm_lin_quad_mixed_" + c[0] + "_" + c[1] in matrix.keys():
+            elif "sm_lin_quad_mixed_" + c[0] + "_" + c[1] in list(matrix.keys()):
                name = "mix_" + c[1] + "_" + c[0]
                matrix[name] = matrix["sm_lin_quad_mixed_" + c[0] + "_" + c[1]].Clone(name)
                matrix[name].Add(matrix["sm"])
@@ -256,7 +256,7 @@ if __name__ == "__main__":
             for i in range(len(ops)+1):
                for j in range(i + 1 ):
                   if fact == 0:
-                     print("[WARNING] sm bin count for bin {} in region {} is ZERO. Will set all EFT to ZERO".format(ibin+1, channel)) 
+                     print(("[WARNING] sm bin count for bin {} in region {} is ZERO. Will set all EFT to ZERO".format(ibin+1, channel))) 
 		     scale_bin.append(0)
                      continue
                   try:

--- a/scripts/convertATGCRooStatToJson.py
+++ b/scripts/convertATGCRooStatToJson.py
@@ -54,16 +54,16 @@ def readBinParab(arg):
     funcname = [i.GetName() for i in f.GetListOfKeys()][0]
     func = f.Get(funcname)
 
-    coeff_dict = {arg["sample"]: {k: func.GetParameter(paramMap[k]) for k in paramMap.keys()}}
+    coeff_dict = {arg["sample"]: {k: func.GetParameter(paramMap[k]) for k in list(paramMap.keys())}}
 
     # normalize by sm weight so that the algebra 
     # reads as EFT2Obs: 1 + Ax + Bxx + Cy + Dyy + Exy + ...
     sm = coeff_dict[arg["sample"]]["sm"]
 
-    for coef in coeff_dict[arg["sample"]].keys():
+    for coef in list(coeff_dict[arg["sample"]].keys()):
         coeff_dict[arg["sample"]][coef] /= sm
 
-    print("--> Parametrization for file {}".format(arg["file"]))
+    print(("--> Parametrization for file {}".format(arg["file"])))
     print(coeff_dict)
 
     return coeff_dict
@@ -144,9 +144,9 @@ if __name__ == "__main__":
 
     coeff_dict = {k: i for k,i in [it_.split(":") for it_ in args.coefficients.split(",")]}
     # need to retrieve the ops:
-    ops = [i.strip("quad_") for i in coeff_dict.keys() if i.startswith("quad_")]
+    ops = [i.strip("quad_") for i in list(coeff_dict.keys()) if i.startswith("quad_")]
 
-    print("--> Detected {} operators: {}".format(len(ops), ops))
+    print(("--> Detected {} operators: {}".format(len(ops), ops)))
 
     # name of the signal processes per bin: anoCoupl_process_ZVBF_ptZ_mu_3D_bin2
     # name of the parabola files : signal_proc_ZVBF_ptZ_el_3D_bin2.root
@@ -178,16 +178,16 @@ if __name__ == "__main__":
     toWrite = {k: [] for k in keys}
     toWrite["parameters"] = ops
     # the only key in the list of coeffs is the bin name as writtten in datacard
-    toWrite["bin_labels"] = [i.keys()[0] for i in coeffs]
+    toWrite["bin_labels"] = [list(i.keys())[0] for i in coeffs]
 
     # now contruct the parametrization in a compatible way
     bins = []
     for c in coeffs:
         ov = []
-        sample = c.keys()[0]
+        sample = list(c.keys())[0]
         coeff = c[sample]
 
-        for cv in coeff.keys():
+        for cv in list(coeff.keys()):
             if cv.startswith("lin"):
                 ov.append([coeff[cv], coeff[cv], cv.strip("lin_")])
             elif cv.startswith("quad"):

--- a/scripts/mkEFTGifs.py
+++ b/scripts/mkEFTGifs.py
@@ -149,7 +149,7 @@ if __name__ == "__main__":
         hh.setShapes(file_)
         hh.setScan(args.scan, "limit")
         hh.setScanMaxNLL(args.maxNLL)
-        hh.setRateParam(map.values())
+        hh.setRateParam(list(map.values()))
         hh.runHistoryEFTNeg()
         
         scan = hh.getScan()
@@ -162,8 +162,8 @@ if __name__ == "__main__":
         signals = hh.getExpectedSigNames()
         bkg = [i for i in processes if i not in signals]
   
-        print("--> Signals: ", signals)
-        print("--> Background: ", bkg)
+        print(("--> Signals: ", signals))
+        print(("--> Background: ", bkg))
         colors = [ROOT.kRed, ROOT.kBlue, ROOT.kCyan, ROOT.kViolet, ROOT.kGray, ROOT.kMagenta, ROOT.kSpring, ROOT.kGreen, ROOT.kTeal, ROOT.kOrange, ROOT.kYellow, ROOT.kAzure, ROOT.kCyan+2, ROOT.kCyan+5]
         
         histos["sm"].SetFillColor(ROOT.kGray)
@@ -257,7 +257,7 @@ if __name__ == "__main__":
                         bkgs = {}
 
                         v_ = ""
-                        if reg in vars.keys():
+                        if reg in list(vars.keys()):
                             v_ = vars[reg]
             
                         bkg_shapes = ROOT.THStack("hs",";{};{}".format(v_, "Events"))
@@ -272,7 +272,7 @@ if __name__ == "__main__":
                             # h.SetFillColor(colors[idx_])
                             h.SetFillColor(cols[col_idx])
                             leg.AddEntry(h, b, "F")
-                            if b in map.keys():
+                            if b in list(map.keys()):
                                 h.Scale(rateParams[map[b]][idx])
                             bkgs[b] = deepcopy(h)
                             bkg_shapes.Add(h)
@@ -300,7 +300,7 @@ if __name__ == "__main__":
 
                         fullBSM = deepcopy(histos[j])
                        
-                        for key in bkgs.keys():
+                        for key in list(bkgs.keys()):
                             fullBSM.Add(bkgs[key])
 
                          
@@ -341,7 +341,7 @@ if __name__ == "__main__":
                         sm = deepcopy(histos["sm"])
 
                         v_ = ""
-                        if reg in vars.keys():
+                        if reg in list(vars.keys()):
                             v_ = vars[reg]
                         
                         max_ = sm.GetMaximum()
@@ -403,7 +403,7 @@ if __name__ == "__main__":
 
 
                         v_ = ""
-                        if reg in vars.keys():
+                        if reg in list(vars.keys()):
                             v_ = vars[reg]
 
                         
@@ -430,7 +430,7 @@ if __name__ == "__main__":
                         h_err2.Draw("E2 same")
 
 
-                        for template in hh.historySingleHistos[j].keys():
+                        for template in list(hh.historySingleHistos[j].keys()):
                             
                             hh.historySingleHistos[j][template].SetLineColorAlpha(ROOT.kAzure+1, 0.3)
                             hh.historySingleHistos[j][template].SetFillColor(0)

--- a/scripts/mkEFTGifsRegions.py
+++ b/scripts/mkEFTGifsRegions.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
         hh.setShapes(file_)
         hh.setScan(args.scan, "limit")
         hh.setScanMaxNLL(args.maxNLL)
-        hh.setRateParam(map.values())
+        hh.setRateParam(list(map.values()))
         hh.runHistoryEFTNeg()
 
         builders[reg] = hh
@@ -290,7 +290,7 @@ if __name__ == "__main__":
                 bkgs = {}
 
                 v_ = ""
-                if reg in vars.keys():
+                if reg in list(vars.keys()):
                     v_ = vars[reg]
     
                 bkg_shapes = ROOT.THStack("hs_{}",";{};{}".format(reg, v_, "Events"))
@@ -305,7 +305,7 @@ if __name__ == "__main__":
                     # h.SetFillColor(colors[idx_])
                     h.SetFillColor(cols[col_idx])
                     leg.AddEntry(h, b, "F")
-                    if b in map.keys():
+                    if b in list(map.keys()):
                         h.Scale(rateParams[map[b]][idx])
                     bkgs[b] = deepcopy(h)
                     bkg_shapes.Add(h)
@@ -335,7 +335,7 @@ if __name__ == "__main__":
 
                 fullBSM = deepcopy(histos[j])
                 
-                for key in bkgs.keys():
+                for key in list(bkgs.keys()):
                     fullBSM.Add(bkgs[key])
 
                     

--- a/scripts/mkEFTScan.py
+++ b/scripts/mkEFTScan.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     if len(args.POI) > 2:
-        print("[ERROR] Specified {} operators to be plotted but only 2 are supported for plotting purposes".format(len(args.pois))) 
+        print(("[ERROR] Specified {} operators to be plotted but only 2 are supported for plotting purposes".format(len(args.pois)))) 
 
     ROOT.gROOT.SetBatch(1)
     ROOT.gStyle.SetOptStat(0000)

--- a/scripts/mkPlotEFT.py
+++ b/scripts/mkPlotEFT.py
@@ -35,7 +35,7 @@ class Scythe:
     # _____________________________________________________________________________
     def defineStyle(self):
     
-        print "=================="
+        print("==================")
         import HiggsAnalysis.AnalyticAnomalousCoupling.tdrStyle as tdrStyle
         tdrStyle.setTDRStyle()
         
@@ -45,11 +45,11 @@ class Scythe:
     # _____________________________________________________________________________
     def makePlotEFT(self):
 
-        print "==================="
-        print "==== mkPlotEFT ===="
-        print "==================="
+        print("===================")
+        print("==== mkPlotEFT ====")
+        print("===================")
         
-        print " self._pairs " , self._pairs
+        print(" self._pairs " , self._pairs)
         
         self.defineStyle()
         
@@ -83,8 +83,8 @@ class Scythe:
                
         cc_all_together = ROOT.TCanvas("cc_all_together", "", 800, 600)
         histo_sm  = fileIn.Get( self._folderName + "histo_" + self._sampleNameSM)
-        print " name histo = " , self._folderName + "histo_" + self._sampleNameSM
-        print " histo_sm --> " , histo_sm.Class()
+        print(" name histo = " , self._folderName + "histo_" + self._sampleNameSM)
+        print(" histo_sm --> " , histo_sm.Class())
         histo_sm.SetLineColor( ROOT.kBlue )
         histo_sm.SetLineWidth( 2 )
         histo_sm.Draw()
@@ -98,7 +98,7 @@ class Scythe:
         histos_varied = {}
         
         counter = 0
-        for nameHR, pair in self._pairs.iteritems():
+        for nameHR, pair in self._pairs.items():
         
           self._outFile.mkdir ( nameHR )
           self._outFile.cd    ( nameHR )
@@ -106,7 +106,7 @@ class Scythe:
           histo_bsm_x  =  fileIn.Get( self._folderName + "histo_" + "quadratic_" + pair['xName'] ) 
           histo_int_x  =  fileIn.Get( self._folderName + "histo_" + "linear_"    + pair['xName'] ) 
           
-          if 'yName' in pair.keys() :
+          if 'yName' in list(pair.keys()) :
             histo_bsm_y  =  fileIn.Get( self._folderName + "histo_" + "quadratic_" + pair['yName'] ) 
             histo_int_y  =  fileIn.Get( self._folderName + "histo_" + "linear_"    + pair['yName'] ) 
             histo_int_xy =  fileIn.Get( self._folderName + "histo_" + "linear_mixed_" + pair['xName'] + "_" + pair['yName'] ) 
@@ -118,7 +118,7 @@ class Scythe:
           histos_varied[counter].Add( histo_bsm_x  , ( pair['xValue'] * pair['xValue'] ) )
           histos_varied[counter].Add( histo_int_x  , ( pair['xValue']                  ) )
 
-          if 'yName' in pair.keys() :
+          if 'yName' in list(pair.keys()) :
             histos_varied[counter].Add( histo_bsm_y  , ( pair['yValue'] * pair['yValue'] ) )
             histos_varied[counter].Add( histo_int_y  , ( pair['yValue']                  ) )
             histos_varied[counter].Add( histo_int_xy , ( pair['xValue'] * pair['yValue'] ) )
@@ -128,7 +128,7 @@ class Scythe:
           
           histos_varied[counter].Write()
 
-          if 'yName' in pair.keys() :
+          if 'yName' in list(pair.keys()) :
             leg.AddEntry(histos_varied[counter], pair['xName'] + " = " + str(pair['xValue']) + " ; " + pair['yName'] + " = " + str(pair['yValue']) ,"L")
           else :
             leg.AddEntry(histos_varied[counter], pair['xName'] + " = " + str(pair['xValue'])  ,"L")
@@ -152,7 +152,7 @@ class Scythe:
 if __name__ == '__main__':
     sys.argv = argv
     
-    print '''
+    print('''
 ----------------------------------------------------------------------------------------------------------------------------------
 
        ____|  ____| __ __|             |         |         
@@ -162,7 +162,7 @@ if __name__ == '__main__':
                                _|                          
      
 ----------------------------------------------------------------------------------------------------------------------------------
-'''    
+''')    
 
     usage = 'usage: %prog [options]'
     parser = optparse.OptionParser(usage)
@@ -181,11 +181,11 @@ if __name__ == '__main__':
     sys.argv.append( '-b' )
     ROOT.gROOT.SetBatch()
 
-    print " inputFileROOT         =          ", opt.inputFileROOT
-    print " inputFilePairs        =          ", opt.inputFilePairs
-    print " outputFile            =          ", opt.outputFile
-    print " sampleNameSM          =          ", opt.sampleNameSM
-    print " folderName            =          ", opt.folderName
+    print(" inputFileROOT         =          ", opt.inputFileROOT)
+    print(" inputFilePairs        =          ", opt.inputFilePairs)
+    print(" outputFile            =          ", opt.outputFile)
+    print(" sampleNameSM          =          ", opt.sampleNameSM)
+    print(" folderName            =          ", opt.folderName)
 
 
     factory = Scythe()
@@ -210,7 +210,7 @@ if __name__ == '__main__':
 
     factory.makePlotEFT()
     
-    print '... and now closing ...'
+    print('... and now closing ...')
         
        
        

--- a/scripts/scan.py
+++ b/scripts/scan.py
@@ -45,7 +45,7 @@ class scanEFT:
             n = t.Draw( to_draw.Data() , "deltaNLL<{} && deltaNLL>{}".format(self.upper,self.lower), "l")
 
             if n <= 1: 
-                print("[ATTENTION] no likelihood for {}".format(self.poi))
+                print(("[ATTENTION] no likelihood for {}".format(self.poi)))
                 return
 
 
@@ -93,7 +93,7 @@ class scanEFT:
             n = t.Draw( to_draw.Data() , "deltaNLL<{} && deltaNLL>{}".format(self.upper,self.lower), "l")
 
             if n <= 1: 
-                print("[ATTENTION] no likelihood for {}".format(self.poi))
+                print(("[ATTENTION] no likelihood for {}".format(self.poi)))
                 return
 
             x = np.ndarray((n), 'd', t.GetV1())

--- a/scripts/summaryPlotMultiple.py
+++ b/scripts/summaryPlotMultiple.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     # scale operators
     scale = [i.split(":") for i in args.scale.split(",") if i != ""]
     for sf in scale:
-        print("--> Will scale {} by {}".format(sf[0], sf[1]))
+        print(("--> Will scale {} by {}".format(sf[0], sf[1])))
         scale_operator(plot, sf[0], float(sf[1]))
 
     c = ROOT.TCanvas("c", "c", 2000, 1500)
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     import math as mt
     step = 0.5
     edges = [-1]
-    for key in plot.keys():
+    for key in list(plot.keys()):
         current = edges[-1]
         edges.append(mt.ceil(len(plot[key]["interval"])*0.3) + current)
 
@@ -83,7 +83,7 @@ if __name__ == "__main__":
     h = ROOT.TH1F("labels", "labels", len(edges)-1, edges)
     for idx, i in enumerate(plot.keys()):
         label = i
-        if i in poi_to_label.keys(): label = poi_to_label[i]
+        if i in list(poi_to_label.keys()): label = poi_to_label[i]
         h.GetXaxis().SetBinLabel(idx+1, label) 
 
     h.SetTitle("")

--- a/scripts/utils/functions.py
+++ b/scripts/utils/functions.py
@@ -5,7 +5,7 @@ from array import array
 def _getColor(color):
       if type(color) == int:
         return color
-      elif type(color) == long:
+      elif type(color) == int:
         return int(color)
       elif type(color) == tuple:
         # RGB
@@ -17,11 +17,11 @@ def _getColor(color):
 def filter_common_ops_(d, limits="expected"):
     
     #print(d.keys())
-    if len(d.keys()) <= 1 :  return 
+    if len(list(d.keys())) <= 1 :  return 
 
     ops_ = []
-    for an in d.keys():
-         ops_.append(d[an]["constraints"][limits].keys())
+    for an in list(d.keys()):
+         ops_.append(list(d[an]["constraints"][limits].keys()))
     
     # select only the operators common to at least 2 analyses
     op_retained = []
@@ -33,25 +33,25 @@ def filter_common_ops_(d, limits="expected"):
             if op in op_retained: continue
             if any(op in j for j in to_scan): op_retained.append(op)
             else: 
-                print("--> Not considring " + op)
+                print(("--> Not considring " + op))
                 op_discarded.append(op)
     
     # now delete from original dictionary the discarded operators
-    for an in d.keys():
+    for an in list(d.keys()):
         for op in op_discarded:
-            if op in d[an]["constraints"][limits].keys(): del d[an]["constraints"][limits][op]
+            if op in list(d[an]["constraints"][limits].keys()): del d[an]["constraints"][limits][op]
 
 
 def filter_for_analysis_(d, analysis_key, limits="expected"):
     
     # these are the ops of interest
-    ops = d[analysis_key]["constraints"][limits].keys()
+    ops = list(d[analysis_key]["constraints"][limits].keys())
     
     # now cycle on all analyses and retain only ops of interest
-    for an in d.keys():
+    for an in list(d.keys()):
         if an == analysis_key: continue
         # check ops not present in baseline list
-        op_discarded = [i for i in d[an]["constraints"][limits].keys() if not i in ops]
+        op_discarded = [i for i in list(d[an]["constraints"][limits].keys()) if not i in ops]
         # and delete
         for op in op_discarded:
             del d[an]["constraints"][limits][op]
@@ -59,9 +59,9 @@ def filter_for_analysis_(d, analysis_key, limits="expected"):
             
     # if the analysis has no common operators with baseline, delete
     del_an = []
-    for an in d.keys():
-        if len(d[an]["constraints"][limits].keys())==0: 
-            print("-- Deleting analysis " + an)
+    for an in list(d.keys()):
+        if len(list(d[an]["constraints"][limits].keys()))==0: 
+            print(("-- Deleting analysis " + an))
             del_an.append(an)
     
     for d_an in del_an: del d[d_an]
@@ -70,9 +70,9 @@ def filter_for_analysis_(d, analysis_key, limits="expected"):
 def revert_dictionary(d, limits="expected"):
     # invert the logic: analyses: ops -> ops: analyses
     new_d = {}
-    for an in d.keys():
-        for op in d[an]["constraints"][limits].keys():
-            if op not in new_d.keys(): 
+    for an in list(d.keys()):
+        for op in list(d[an]["constraints"][limits].keys()):
+            if op not in list(new_d.keys()): 
                 new_d[op] = {"legend_names": [], "reference": [], "best_fit": [], "interval": [], "colors": []}
             
             #print(d[an])
@@ -82,13 +82,13 @@ def revert_dictionary(d, limits="expected"):
             new_d[op]["interval"].append(d[an]["constraints"][limits][op][1:])
             
             color = ROOT.kBlack
-            if "color" in d[an].keys(): color = d[an]["color"]
+            if "color" in list(d[an].keys()): color = d[an]["color"]
             new_d[op]["colors"].append(d[an]["color"])
             
     return new_d
 
 def scale_operator(plot_dict, op, factor):
-    if op not in plot_dict.keys(): return 
+    if op not in list(plot_dict.keys()): return 
     new_name = op + "#times" + str(factor)
     plot_dict[new_name] = plot_dict.pop(op)
     for idx in range(len(plot_dict[new_name]["interval"])):
@@ -98,14 +98,14 @@ def scale_operator(plot_dict, op, factor):
 
 def remove_analyses(d, keys):
     remove = []
-    for k in d.keys():
+    for k in list(d.keys()):
         if k in keys: remove.append(k)
     for i in remove:
         del d[i]
     
 def keep_analyses(d, keys):
     remove = []
-    for k in d.keys():
+    for k in list(d.keys()):
         if k not in keys: remove.append(k)
     for i in remove:
         del d[i]
@@ -256,7 +256,7 @@ def convert_dict_to_objects(d, h):
 def printTable(an, columns="ops"):
     ops = []
     analyses = []
-    for key in an.keys():
+    for key in list(an.keys()):
         analyses.append(an[key]["name"])
         for op in an[key]["constraints"]["expected"]: 
             if op not in ops: ops.append(op)
@@ -269,7 +269,7 @@ def printTable(an, columns="ops"):
         print("\\small")
         print("\\begin{center}")
         print("\\renewcommand{\\arraystretch}{1.2}")
-        print("\\begin{tabular}{" + l + "}")
+        print(("\\begin{tabular}{" + l + "}"))
         print("\\hline")
 
         line = "   \\textbf{Analyses / W.C. [TeV$^{-2}$] } & "
@@ -281,7 +281,7 @@ def printTable(an, columns="ops"):
         for an_ in analyses:
 
             l = " \\textbf{" + an_.replace("#", "\\") + "} & "
-            for key in an.keys():
+            for key in list(an.keys()):
                 if an[key]["name"] != an_: continue
                 else:
                     for op in ops:
@@ -310,7 +310,7 @@ def printTable(an, columns="ops"):
         print("\\small")
         print("\\begin{center}")
         print("\\renewcommand{\\arraystretch}{1.2}")
-        print("\\begin{tabular}{" + l + "}")
+        print(("\\begin{tabular}{" + l + "}"))
         print("\\hline")
 
         line = "   \\textbf{ W.C. [TeV$^{-2}$] / Analyses } & "
@@ -322,7 +322,7 @@ def printTable(an, columns="ops"):
         for coef in ops:
             l = "\\textbf{" + coef + "}& "
             for ana in analyses:
-                for key in an.keys():
+                for key in list(an.keys()):
                     if an[key]["name"] != ana: continue
                     else:
                         if coef in an[key]["constraints"]["expected"]:


### PR DESCRIPTION
We are working on the SMP-EFT combination and want to use the AnalyticAnomalousCoupling model with the latest combine version, so we need to port the code to python3. I've done this by using the 2to3 script as follows:
`find . -name "*.py" -exec 2to3 -w -n -j 8 {} \;`

We could have a separate branch with this python3 version so it does not clash with the master. 